### PR TITLE
Updating TrueBlocks numbers (now agree with other issuance methods)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,17 +108,17 @@ Please help fill out these tables with pull requests (or contact me with your re
 | Block Number | Ethereum Client (sync type) | [eth-total-supply](https://github.com/lastmjs/eth-total-supply) | [ethsupply](https://github.com/madumas/ethsupply) | [TrueBlocks<br/>(fix pending)](https://github.com/Great-Hill-Corporation/trueblocks-core/tree/develop/src/other/issuance) | [CurrencyTycoom](https://github.com/CurrencyTycoon/mysupplyaudit) |
 | --- | --- | --- | --- | --- | --- |
 | 0 | Geth (fast sync) | 72009990.49948 | 72009990.49948 | 72009990.49948 |
-| 1000000 | Geth (fast sync) | 77311912.99948 | 77311912.99948 | 77311905.18698 |
-| 2000000 | Geth (fast sync) | 82594620.18698 | 82594620.18698 | 82594612.37448 |
-| 3000000 | Geth (fast sync) | 87918591.90573 | 87918591.90573 | 87918584.09323 |
-| 4000000 | Geth (fast sync) | 93163545.49948 | 93163545.49948 | 93163537.68698 |
-| 5000000 | Geth (fast sync) | 97303827.65573 | 97303827.65573 | 97303819.84323 |
-| 6000000 | Geth (fast sync) |                | 100813970.71823 | 100813962.90573 |
-| 7000000 | Geth (fast sync) |                | 104160558.46823 | 104160550.65573 |
-| 8000000 | Geth (fast sync) |                | 106578031.28073 | 106578023.46823 |
-| 9000000 | Geth (fast sync) |                | 108691156.40573 | 108691148.59323 |
-| 9193265 (the last block in 2019 UTC) | Geth (fast sync) | | 109094014.21823 | |
-| 10000000 | Geth (fast sync) | | | 110787755.7807300 |
+| 1000000 | Geth (fast sync) | 77311912.99948 | 77311912.99948 | 77311912.99948 |
+| 2000000 | Geth (fast sync) | 82594620.18698 | 82594620.18698 | 82594620.18698 | |
+| 3000000 | Geth (fast sync) | 87918591.90573 | 87918591.90573 | 87918591.90573 | |
+| 4000000 | Geth (fast sync) | 93163545.49948 | 93163545.49948 | 93163545.49948 | |
+| 5000000 | Geth (fast sync) | 97303827.65573 | 97303827.65573 | 97303827.65573 | |
+| 6000000 | Geth (fast sync) |                | 100813970.71823 | 100813970.71823 | |
+| 7000000 | Geth (fast sync) |                | 104160558.46823 | 104160558.46823 | |
+| 8000000 | Geth (fast sync) |                | 106578031.28073 | 106578031.28073 | |
+| 9000000 | Geth (fast sync) |                | 108691156.40573 | 108691156.40573 | |
+| 9193265 (the last block in 2019 UTC) | Geth (fast sync) | | 109094014.21823 | 109094014.21823 |
+| 10000000 | Geth (fast sync) | | | 110787763.59323 |
 
 ### Total ETH Account Balances
 

--- a/README.md
+++ b/README.md
@@ -105,20 +105,20 @@ Please help fill out these tables with pull requests (or contact me with your re
 
 ### Total ETH Issued
 
-| Block Number | Ethereum Client (sync type) | [eth-total-supply](https://github.com/lastmjs/eth-total-supply) | [ethsupply](https://github.com/madumas/ethsupply) | [TrueBlocks<br/>(fix pending)](https://github.com/Great-Hill-Corporation/trueblocks-core/tree/develop/src/other/issuance) | [CurrencyTycoom](https://github.com/CurrencyTycoon/mysupplyaudit) |
+| Block Number | [eth-total-supply](https://github.com/lastmjs/eth-total-supply)<br/>(geth fast sync) | [ethsupply](https://github.com/madumas/ethsupply)<br/>(geth fast sync) | [TrueBlocks](https://github.com/Great-Hill-Corporation/trueblocks-core/tree/develop/src/other/issuance)<br/>(parity archive) | [CurrencyTycoon](https://github.com/CurrencyTycoon/mysupplyaudit)<br/>(geth fast sync) |
 | --- | --- | --- | --- | --- | --- |
-| 0 | Geth (fast sync) | 72009990.49948 | 72009990.49948 | 72009990.49948 |
-| 1000000 | Geth (fast sync) | 77311912.99948 | 77311912.99948 | 77311912.99948 |
-| 2000000 | Geth (fast sync) | 82594620.18698 | 82594620.18698 | 82594620.18698 | |
-| 3000000 | Geth (fast sync) | 87918591.90573 | 87918591.90573 | 87918591.90573 | |
-| 4000000 | Geth (fast sync) | 93163545.49948 | 93163545.49948 | 93163545.49948 | |
-| 5000000 | Geth (fast sync) | 97303827.65573 | 97303827.65573 | 97303827.65573 | |
-| 6000000 | Geth (fast sync) |                | 100813970.71823 | 100813970.71823 | |
-| 7000000 | Geth (fast sync) |                | 104160558.46823 | 104160558.46823 | |
-| 8000000 | Geth (fast sync) |                | 106578031.28073 | 106578031.28073 | |
-| 9000000 | Geth (fast sync) |                | 108691156.40573 | 108691156.40573 | |
-| 9193265 (the last block in 2019 UTC) | Geth (fast sync) | | 109094014.21823 | 109094014.21823 |
-| 10000000 | Geth (fast sync) | | | 110787763.59323 |
+| 0 |  72009990.49948 | 72009990.49948 | 72009990.49948 | |
+| 1000000 |  77311912.99948 | 77311912.99948 | 77311912.99948 | |
+| 2000000 |  82594620.18698 | 82594620.18698 | 82594620.18698 | |
+| 3000000 |  87918591.90573 | 87918591.90573 | 87918591.90573 | |
+| 4000000 |  93163545.49948 | 93163545.49948 | 93163545.49948 | |
+| 5000000 |  97303827.65573 | 97303827.65573 | 97303827.65573 | |
+| 6000000 |                 | 100813970.71823 | 100813970.71823 | |
+| 7000000 |                 | 104160558.46823 | 104160558.46823 | |
+| 8000000 |                 | 106578031.28073 | 106578031.28073 | |
+| 9000000 |                 | 108691156.40573 | 108691156.40573 | |
+| 9193265<br/>(last in 2019 UTC) | | 109094014.21823 | 109094014.21823 | |
+| 10000000 |     | | 110787763.59323 | |
 
 ### Total ETH Account Balances
 


### PR DESCRIPTION
We found a small bug (two uncle blocks had `0x0` their beneficiary, which we were missing). Correcting this allowed all our numbers to match the other numbers. Also, these data are now `audited` as per above.